### PR TITLE
Added special color palette for `nav_msgs/OccupancyGrid`

### DIFF
--- a/packages/webviz-core/src/hooksImporter.js
+++ b/packages/webviz-core/src/hooksImporter.js
@@ -83,7 +83,8 @@ export function perPanelHooks() {
   const RobotIcon = require("@mdi/svg/svg/robot.svg").default;
   const CubeOutline = require("@mdi/svg/svg/cube-outline.svg").default;
   const LaserScanVert = require("webviz-core/src/panels/ThreeDimensionalViz/LaserScanVert").default;
-  const { defaultMapPalette } = require("webviz-core/src/panels/ThreeDimensionalViz/commands/utils");
+  const { defaultMapPalette, defaultObstacleGridPalette } = require("webviz-core/src/panels/ThreeDimensionalViz/commands/utils");
+
   const {
     GEOMETRY_MSGS_POLYGON_STAMPED_DATATYPE,
     NAV_MSGS_OCCUPANCY_GRID_DATATYPE,
@@ -188,7 +189,7 @@ export function perPanelHooks() {
         "text",
         "triangleList",
       ],
-      renderAdditionalMarkers: () => {},
+      renderAdditionalMarkers: () => { },
       topics: [],
       iconsByDatatype: {
         [VISUALIZATION_MSGS_MARKER_DATATYPE]: HexagonIcon,
@@ -211,10 +212,12 @@ export function perPanelHooks() {
       AdditionalToolbarItems: () => null,
       LaserScanVert,
       sceneBuilderHooks: require("webviz-core/src/panels/ThreeDimensionalViz/SceneBuilder/defaultHooks").default,
-      getMapPalette() {
+      getMapPalette(maptype: string) {
+        if (maptype == "local_obstacles")
+          return defaultObstacleGridPalette;
         return defaultMapPalette;
       },
-      consumePose: () => {},
+      consumePose: () => { },
       ungroupedNodesCategory: "Topics",
       rootTransformFrame: "map",
       defaultFollowTransformFrame: null,

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/SceneBuilder/defaultHooks.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/SceneBuilder/defaultHooks.js
@@ -10,7 +10,7 @@ import type { ThreeDimensionalVizHooks } from "./types";
 import { TF_DATATYPE } from "webviz-core/src/util/globalConstants";
 
 const sceneBuilderHooks: ThreeDimensionalVizHooks = {
-  getSelectionState: () => {},
+  getSelectionState: () => { },
   getTopicsToRender: () => new Set(),
   consumeBobject: (topic, datatype, msg, consumeMethods, { errors }) => {
     // TF messages are consumed by TransformBuilder, not SceneBuilder.
@@ -22,7 +22,19 @@ const sceneBuilderHooks: ThreeDimensionalVizHooks = {
   addMarkerToCollector: () => false,
   getSyntheticArrowMarkerColor: () => ({ r: 0, g: 0, b: 1, a: 0.5 }),
   getFlattenedPose: () => undefined,
-  getOccupancyGridValues: (_topic) => [0.5, "map"],
+  getOccupancyGridValues: (settings) => {
+    let map = "map";
+    let alpha = 0.5
+    if (settings) {
+      if (settings.map) {
+        map = settings.map;
+      }
+      if (settings.alpha) {
+        alpha = settings.alpha;
+      }
+    }
+    return [alpha, map];
+  },
   getMarkerColor: (topic, markerColor) => markerColor,
   skipTransformFrame: null,
 };

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/SceneBuilder/index.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/SceneBuilder/index.js
@@ -909,7 +909,7 @@ export default class SceneBuilder implements MarkerProvider {
         if (pathStamped.poses().length() === 0) {
           break;
         }
-        const { overrideColor } = this._settingsByKey[`t:${topic}`] || { r: 1, g: 0, b: 0, a: 1 };
+        const overrideColor = this._settingsByKey[`t:${topic}`]?.overrideColor || { r: 1, g: 0, b: 0, a: 1 };
         const newMessage = {
           header: deepParse(pathStamped.header()),
           // TODO(@cjds) Make this make use of the orientation of the poses in the path as well
@@ -934,6 +934,8 @@ export default class SceneBuilder implements MarkerProvider {
         // convert Polygon to a line strip
         const polygonStamped = cast < BinaryPolygonStamped > (message);
         const polygon = polygonStamped.polygon();
+        const overrideColor = this._settingsByKey[`t:${topic}`]?.overrideColor || { r: 0, g: 1, b: 0, a: 1 };
+        const scale = this._settingsByKey[`t:${topic}`]?.scale || 0.2;
         if (polygon.points().length() === 0) {
           break;
         }
@@ -941,8 +943,8 @@ export default class SceneBuilder implements MarkerProvider {
           header: deepParse(polygonStamped.header()),
           points: deepParse(polygon.points()),
           closed: true,
-          scale: { x: 0.2 },
-          color: { r: 0, g: 1, b: 0, a: 1 },
+          scale: { x: scale },
+          color: overrideColor
         };
         this._consumeNonMarkerMessage(topic, newMessage, 4 /* line strip */, message);
         break;

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/SceneBuilder/index.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/SceneBuilder/index.js
@@ -707,7 +707,6 @@ export default class SceneBuilder implements MarkerProvider {
 
   _consumeOccupancyGrid = (topic: string, message: NavMsgs$OccupancyGrid): void => {
     const { frame_id } = message.header;
-
     if (!frame_id) {
       this._addError(this.errors.topicsMissingFrameIds, topic);
       return;
@@ -732,7 +731,7 @@ export default class SceneBuilder implements MarkerProvider {
 
     // set ogrid texture & alpha based on current rviz settings
     // in the future these will be customizable via the UI
-    const [alpha, map] = this._hooks.getOccupancyGridValues(topic);
+    const [alpha, map] = this._hooks.getOccupancyGridValues(this._settingsByKey[`t:${topic}`]);
 
     const mappedMessage = {
       ...message,

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/OccupancyGridSettingsEditor.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/OccupancyGridSettingsEditor.js
@@ -6,18 +6,14 @@
 //  found in the LICENSE file in the root directory of this source tree.
 //  You may not use this file except in compliance with the License.
 
-import CheckboxBlankOutlineIcon from "@mdi/svg/svg/checkbox-blank-outline.svg";
-import CheckboxMarkedIcon from "@mdi/svg/svg/checkbox-marked.svg";
-import InformationIcon from "@mdi/svg/svg/information.svg";
 import React from "react";
 
 import { type TopicSettingsEditorProps } from ".";
-import ColorPickerForTopicSettings from "./ColorPickerForTopicSettings";
 import { SLabel, SInput } from "./common";
 import Flex from "webviz-core/src/components/Flex";
 import Icon from "webviz-core/src/components/Icon";
 import { getGlobalHooks } from "webviz-core/src/loadWebviz";
-import type { PoseStamped } from "webviz-core/src/types/Messages";
+import type { OccupancyGridMessage } from "webviz-core/src/types/Messages";
 import { colors } from "webviz-core/src/util/sharedStyleConstants";
 
 type OccupancyGridSettings = {|
@@ -25,7 +21,7 @@ type OccupancyGridSettings = {|
         map ?: "map" | "local_obstacles",
 |};
 
-export default function OccupancyGridSettingsEditor(props: TopicSettingsEditorProps<PoseStamped, OccupancyGridSettings>) {
+export default function OccupancyGridSettingsEditor(props: TopicSettingsEditorProps<OccupancyGridMessage, OccupancyGridSettings>) {
     const { message, settings, onFieldChange, onSettingsChange } = props;
     const badrgbOverloadTypeSetting = React.useMemo(() => !["map", "local_obstacles"].includes(settings.map), [
         settings,

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/OccupancyGridSettingsEditor.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/OccupancyGridSettingsEditor.js
@@ -1,0 +1,77 @@
+// @flow
+//
+//  Copyright (c) 2020-present, Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+import CheckboxBlankOutlineIcon from "@mdi/svg/svg/checkbox-blank-outline.svg";
+import CheckboxMarkedIcon from "@mdi/svg/svg/checkbox-marked.svg";
+import InformationIcon from "@mdi/svg/svg/information.svg";
+import React from "react";
+
+import { type TopicSettingsEditorProps } from ".";
+import ColorPickerForTopicSettings from "./ColorPickerForTopicSettings";
+import { SLabel, SInput } from "./common";
+import Flex from "webviz-core/src/components/Flex";
+import Icon from "webviz-core/src/components/Icon";
+import { getGlobalHooks } from "webviz-core/src/loadWebviz";
+import type { PoseStamped } from "webviz-core/src/types/Messages";
+import { colors } from "webviz-core/src/util/sharedStyleConstants";
+
+type OccupancyGridSettings = {|
+    alpha?: number,
+        map ?: "map" | "local_obstacles",
+|};
+
+export default function OccupancyGridSettingsEditor(props: TopicSettingsEditorProps<PoseStamped, OccupancyGridSettings>) {
+    const { message, settings, onFieldChange, onSettingsChange } = props;
+    const badrgbOverloadTypeSetting = React.useMemo(() => !["map", "local_obstacles"].includes(settings.map), [
+        settings,
+    ]);
+    const alpha = settings.alpha != null ? settings.alpha : 0.5;
+
+    if (!message) {
+        return (
+            <div style={{ color: colors.TEXT_MUTED }}>
+                <small>Waiting for messages...</small>
+            </div>
+        );
+    }
+    const copy = getGlobalHooks().perPanelHooks().ThreeDimensionalViz.copy.OccupancyGridSettingsEditor;
+    return (
+        <Flex col>
+            <SLabel>NOTE: Changes in this panel will only take effect when you play next or move the slider.</SLabel>
+            <SLabel>Map Colors</SLabel>
+            <div
+                style={{ display: "flex", margin: "4px", flexDirection: "column" }}
+                onChange={(e) => {
+                    onSettingsChange({ ...settings, map: e.target.value });
+                }}>
+                {[
+                    { value: "map", title: "Normal Map Colors" },
+                    { value: "local_obstacles", title: "Local Obstacle Map Colors" },
+                ].map(({ value, title }) => (
+                    <div key={value} style={{ marginBottom: "4px", display: "flex" }}>
+                        <input
+                            type="radio"
+                            value={value}
+                            checked={settings.map === value || (value === "map" && badrgbOverloadTypeSetting)}
+                        />
+                        <label>{title}</label>
+                    </div>
+                ))}
+            </div>
+            <SLabel>Alpha</SLabel>
+            <SInput
+                type="number"
+                value={alpha.toString()}
+                min={0}
+                max={1}
+                step={0.1}
+                onChange={(e) => onSettingsChange({ ...settings, alpha: parseFloat(e.target.value) })}
+            />
+        </Flex>
+    );
+}

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PolygonSettingsEditor.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/PolygonSettingsEditor.js
@@ -1,0 +1,54 @@
+// @flow
+//
+//  Copyright (c) 2020-present, Cruise LLC
+//
+//  This source code is licensed under the Apache License, Version 2.0,
+//  found in the LICENSE file in the root directory of this source tree.
+//  You may not use this file except in compliance with the License.
+
+import React from "react";
+
+import { type TopicSettingsEditorProps } from ".";
+import { SLabel, SInput } from "./common";
+import Flex from "webviz-core/src/components/Flex";
+import Icon from "webviz-core/src/components/Icon";
+import { getGlobalHooks } from "webviz-core/src/loadWebviz";
+import type { OccupancyGridMessage } from "webviz-core/src/types/Messages";
+import { colors } from "webviz-core/src/util/sharedStyleConstants";
+import ColorPickerForTopicSettings from "./ColorPickerForTopicSettings";
+
+type OccupancyGridSettings = {|
+    scale?: number,
+        overrideColor ?: ? string,
+|};
+
+export default function PolygonSettingsEditor(props: TopicSettingsEditorProps<OccupancyGridMessage, PolygonSettings>) {
+    const { message, settings, onFieldChange, onSettingsChange } = props;
+    const alpha = settings.alpha != null ? settings.alpha : 1.0;
+    const scale = settings.scale != null ? settings.scale : 0.2;
+
+    if (!message) {
+        return (
+            <div style={{ color: colors.TEXT_MUTED }}>
+                <small>Waiting for messages...</small>
+            </div>
+        );
+    }
+    const copy = getGlobalHooks().perPanelHooks().ThreeDimensionalViz.copy.OccupancyGridSettingsEditor;
+    return (
+        <Flex col>
+            <SLabel>Color of outline</SLabel>
+            <ColorPickerForTopicSettings
+                color={settings.overrideColor}
+                onChange={(newColor) => onFieldChange("overrideColor", newColor)}
+            />
+            <SLabel>Scale</SLabel>
+            <SInput
+                type="number"
+                value={scale.toString()}
+                step={0.01}
+                onChange={(e) => onSettingsChange({ ...settings, scale: parseFloat(e.target.value) })}
+            />
+        </Flex>
+    );
+}

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/index.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/index.js
@@ -16,6 +16,7 @@ import MarkerSettingsEditor from "./MarkerSettingsEditor";
 import PointCloudSettingsEditor from "./PointCloudSettingsEditor";
 import PoseSettingsEditor from "./PoseSettingsEditor";
 import OccupancyGridSettingsEditor from "./OccupancyGridSettingsEditor";
+import PolygonSettingsEditor from "./PolygonSettingsEditor";
 import styles from "./TopicSettingsEditor.module.scss";
 import ErrorBoundary from "webviz-core/src/components/ErrorBoundary";
 import Flex from "webviz-core/src/components/Flex";
@@ -33,6 +34,7 @@ import {
   WEBVIZ_MARKER_DATATYPE,
   NAV_MSGS_PATH_DATATYPE,
   NAV_MSGS_OCCUPANCY_GRID_DATATYPE,
+  GEOMETRY_MSGS_POLYGON_STAMPED_DATATYPE,
 } from "webviz-core/src/util/globalConstants";
 
 export const LINED_CONVEX_HULL_RENDERING_SETTING = "LinedConvexHull";
@@ -139,6 +141,7 @@ export function topicSettingsEditorForDatatype(datatype: string): ?ComponentType
     "visualization_msgs/MarkerArray": MarkerSettingsEditor,
     [NAV_MSGS_PATH_DATATYPE]: MarkerSettingsEditor,
     [NAV_MSGS_OCCUPANCY_GRID_DATATYPE]: OccupancyGridSettingsEditor,
+    [GEOMETRY_MSGS_POLYGON_STAMPED_DATATYPE]: PolygonSettingsEditor,
     ...getGlobalHooks().perPanelHooks().ThreeDimensionalViz.topicSettingsEditors,
   };
   return editors[datatype];

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/index.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/TopicSettingsEditor/index.js
@@ -15,6 +15,7 @@ import LaserScanSettingsEditor from "./LaserScanSettingsEditor";
 import MarkerSettingsEditor from "./MarkerSettingsEditor";
 import PointCloudSettingsEditor from "./PointCloudSettingsEditor";
 import PoseSettingsEditor from "./PoseSettingsEditor";
+import OccupancyGridSettingsEditor from "./OccupancyGridSettingsEditor";
 import styles from "./TopicSettingsEditor.module.scss";
 import ErrorBoundary from "webviz-core/src/components/ErrorBoundary";
 import Flex from "webviz-core/src/components/Flex";
@@ -31,6 +32,7 @@ import {
   SENSOR_MSGS_LASER_SCAN_DATATYPE,
   WEBVIZ_MARKER_DATATYPE,
   NAV_MSGS_PATH_DATATYPE,
+  NAV_MSGS_OCCUPANCY_GRID_DATATYPE,
 } from "webviz-core/src/util/globalConstants";
 
 export const LINED_CONVEX_HULL_RENDERING_SETTING = "LinedConvexHull";
@@ -118,9 +120,9 @@ export function CommonDecaySettings({
 
 export type TopicSettingsEditorProps<Msg, Settings: {}> = {|
   message: ?Msg,
-  settings: Settings,
-  onFieldChange: (name: string, value: any) => void,
-  onSettingsChange: ({} | (({}) => {})) => void,
+    settings: Settings,
+      onFieldChange: (name: string, value: any) => void,
+        onSettingsChange: ({} | (({ }) => { })) => void,
 |};
 
 export function topicSettingsEditorForDatatype(datatype: string): ?ComponentType<TopicSettingsEditorProps<any, any>> {
@@ -136,10 +138,12 @@ export function topicSettingsEditorForDatatype(datatype: string): ?ComponentType
     "visualization_msgs/Marker": MarkerSettingsEditor,
     "visualization_msgs/MarkerArray": MarkerSettingsEditor,
     [NAV_MSGS_PATH_DATATYPE]: MarkerSettingsEditor,
+    [NAV_MSGS_OCCUPANCY_GRID_DATATYPE]: OccupancyGridSettingsEditor,
     ...getGlobalHooks().perPanelHooks().ThreeDimensionalViz.topicSettingsEditors,
   };
   return editors[datatype];
 }
+
 
 export function canEditDatatype(datatype: string): boolean {
   return topicSettingsEditorForDatatype(datatype) != null;
@@ -153,12 +157,12 @@ export function canEditNamespaceOverrideColorDatatype(datatype: string): boolean
 
 type Props = {|
   topic: Topic,
-  message: any,
-  settings: ?{},
-  onSettingsChange: ({}) => void,
+    message: any,
+      settings: ?{ },
+onSettingsChange: ({ }) => void,
 |};
 
-const TopicSettingsEditor = React.memo<Props>(function TopicSettingsEditor({
+const TopicSettingsEditor = React.memo < Props > (function TopicSettingsEditor({
   topic,
   message,
   settings,

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/commands/OccupancyGrids.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/commands/OccupancyGrids.js
@@ -131,6 +131,7 @@ const occupancyGrids = (regl: any) => {
 type Props = { ...CommonCommandProps, children: OccupancyGridMessage[] };
 
 export default function OccupancyGrids(props: Props) {
+
   // We can click through OccupancyGrids.
   return <Command getChildrenForHitmap={null} {...props} reglCommand={occupancyGrids} />;
 }

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/commands/utils/index.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/commands/utils/index.js
@@ -82,6 +82,43 @@ export const defaultMapPalette = (() => {
   return buff;
 })();
 
+
+export const defaultObstacleGridPalette = (() => {
+  const buff = new Uint8Array(256 * 4);
+
+  // standard gray map palette values
+  for (let i = 0; i <= 100; i++) {
+    const t = 1 - i / 100;
+    const idx = i * 4;
+    setRgba(buff, idx, tinycolor.fromRatio({ r: t, g: t, b: t }));
+  }
+
+  // illegal positive values in green
+  for (let i = 101; i <= 127; i++) {
+    const idx = i * 4;
+    setRgba(buff, idx, tinycolor("lime"));
+  }
+
+  // illegal negative (char) values
+  for (let i = 128; i <= 248; i++) {
+    const idx = i * 4;
+    const t = (i - 128) / (254 - 128);
+    setRgba(buff, idx, tinycolor.fromRatio({ r: t, g: 0.2, b: 0.6, a: Math.max(1 - t, 0.2) }));
+  }
+
+  // legal negative values
+  // https://github.com/cjds/carl/blob/master/carrack_ros/map_updater/include/impl/controller_costmap_republisher_block.hpp#L40
+  setRgba(buff, 255 * 4, COLORS.GRAY.setAlpha(0.5)); // -1 UNKNOWN
+  setRgba(buff, 254 * 4, COLORS.ORANGE.setAlpha(0.5)); // -2 DYNAMIC_OBSTACLE
+  setRgba(buff, 98, COLORS.CYAN.setAlpha(0.5)); // 98 NEAR_DYNAMIC
+  setRgba(buff, 75, COLORS.YELLOW.setAlpha(0.5)); // 75 WARNING
+  setRgba(buff, 1, COLORS.PURPLE.setAlpha(0.5)); // 1 INFLATED_BLUETOOTH
+  setRgba(buff, 100, COLORS.PINK.setAlpha(0.5)); // 100 Static
+  setRgba(buff, 127, COLORS.LIME.setAlpha(0.5)); // 127 TRACKED_OCCUPIED_TO_UNOCCUPIED
+  setRgba(buff, 50, COLORS.AQUA.setAlpha(0.5)); // 50 FLATTENED
+  return buff;
+})();
+
 // convert a number array to a typed array
 // passing a typed array to regl is orders of magnitude
 // faster than passing a number[] and letting regl do the conversion

--- a/packages/webviz-core/src/panels/ThreeDimensionalViz/commands/utils/index.js
+++ b/packages/webviz-core/src/panels/ThreeDimensionalViz/commands/utils/index.js
@@ -10,6 +10,7 @@ import tinycolor from "tinycolor2";
 import type { OccupancyGridMessage } from "webviz-core/src/types/Messages";
 
 export const COLORS = {
+  WHITE: tinycolor("white"),
   BLACK: tinycolor("black"),
   RED: tinycolor("red"),
   PINK: tinycolor("pink"),
@@ -59,17 +60,6 @@ export const defaultMapPalette = (() => {
   }
 
   // legal negative values
-
-  // https://github.com/cjds/carl/blob/master/carrack_ros/map_updater/include/impl/controller_costmap_republisher_block.hpp#L40
-  setRgba(buff, 255 * 4, COLORS.GRAY.setAlpha(0.5)); // -1 UNKNOWN
-  setRgba(buff, 254 * 4, COLORS.ORANGE.setAlpha(0.5)); // -2 DYNAMIC_OBSTACLE
-  setRgba(buff, 98, COLORS.CYAN.setAlpha(0.5)); // 98 NEAR_DYNAMIC
-  setRgba(buff, 75, COLORS.YELLOW.setAlpha(0.5)); // 75 WARNING
-  setRgba(buff, 1, COLORS.PURPLE.setAlpha(0.5)); // 1 INFLATED_BLUETOOTH
-  setRgba(buff, 100, COLORS.PINK.setAlpha(0.5)); // 100 Static
-  setRgba(buff, 127, COLORS.LIME.setAlpha(0.5)); // 127 TRACKED_OCCUPIED_TO_UNOCCUPIED
-  setRgba(buff, 50, COLORS.AQUA.setAlpha(0.5)); // 50 FLATTENED
-
   setRgba(buff, 255 * 4, COLORS.GRAY.setAlpha(0.5)); // -1 UNKNOWN
   setRgba(buff, 254 * 4, COLORS.ORANGE.setAlpha(0.5)); // -2 UNDRIVEABLE
   setRgba(buff, 253 * 4, COLORS.CYAN.setAlpha(0.5)); // -3 SIDEWALK
@@ -110,12 +100,12 @@ export const defaultObstacleGridPalette = (() => {
   // https://github.com/cjds/carl/blob/master/carrack_ros/map_updater/include/impl/controller_costmap_republisher_block.hpp#L40
   setRgba(buff, 255 * 4, COLORS.GRAY.setAlpha(0.5)); // -1 UNKNOWN
   setRgba(buff, 254 * 4, COLORS.ORANGE.setAlpha(0.5)); // -2 DYNAMIC_OBSTACLE
-  setRgba(buff, 98, COLORS.CYAN.setAlpha(0.5)); // 98 NEAR_DYNAMIC
-  setRgba(buff, 75, COLORS.YELLOW.setAlpha(0.5)); // 75 WARNING
-  setRgba(buff, 1, COLORS.PURPLE.setAlpha(0.5)); // 1 INFLATED_BLUETOOTH
-  setRgba(buff, 100, COLORS.PINK.setAlpha(0.5)); // 100 Static
-  setRgba(buff, 127, COLORS.LIME.setAlpha(0.5)); // 127 TRACKED_OCCUPIED_TO_UNOCCUPIED
-  setRgba(buff, 50, COLORS.AQUA.setAlpha(0.5)); // 50 FLATTENED
+  setRgba(buff, 98 * 4, COLORS.CYAN.setAlpha(0.5)); // 98 NEAR_DYNAMIC
+  setRgba(buff, 75 * 4, COLORS.YELLOW.setAlpha(0.5)); // 75 WARNING
+  setRgba(buff, 1 * 4, COLORS.PURPLE.setAlpha(0.5)); // 1 INFLATED_BLUETOOTH
+  setRgba(buff, 100 * 4, COLORS.PINK.setAlpha(0.5)); // 100 Static
+  setRgba(buff, 127 * 4, COLORS.LIME.setAlpha(0.5)); // 127 TRACKED_OCCUPIED_TO_UNOCCUPIED
+  setRgba(buff, 50 * 4, COLORS.AQUA.setAlpha(0.5)); // 50 FLATTENED
   return buff;
 })();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Webviz! To help us understand and review your PR, please fill out the following sections: -->

## Summary

Added our own color palette for nav_msgs/Occupancy Grid


These are the colors I chose
https://github.com/fetchrobotics/webviz/compare/master...cjds:occupancy_grid?expand=1#diff-2a6e9489bfc61d4f68f3a7638750d9206974f462584351233d5becc34c7b9a81R100

![Screenshot from 2021-04-13 12-37-29](https://user-images.githubusercontent.com/4957157/114612298-d3d4ef00-9c56-11eb-9983-6150d97368d2.png)

This is where you can choose if you want map coloring or our new colurs
![image](https://user-images.githubusercontent.com/4957157/114612385-ecdda000-9c56-11eb-980d-01abd0f44220.png)


## Test plan

Tested locally on several bags